### PR TITLE
fix: redirecting to projects page upon click on experiments in breadcumb links

### DIFF
--- a/ui/app/pages/projects/[id]/experiments/index.vue
+++ b/ui/app/pages/projects/[id]/experiments/index.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+const project = inject<Ref<Project>>("project");
+const projectId = computed(() => project!.value?.id);
+
+// Navigating to project page
+navigateTo({
+  name: "projects-id",
+  params: {
+    id: projectId.value
+  },
+});
+</script>
+
+<template>
+  <UCard>
+    <div class="flex justify-center items-center h-24">
+      Navigating to Project {{ projectId }}
+    </div>
+  </UCard>
+</template>


### PR DESCRIPTION
1. Issue fixed when the user clicks on 'experiments' link in breadcumb getting 404 route. So, we are redirecting user to project/:id page