### PR TITLE
fix: table columns, and dropdown height adjusted

### DIFF
--- a/ui/app/assets/css/main.css
+++ b/ui/app/assets/css/main.css
@@ -40,3 +40,27 @@ tr:nth-child(even) {
 .table-cell {
   @apply p-4 text-gray-600 border-b border-gray-200;
 }
+
+
+.experiment-details-table table thead tr td {
+  vertical-align: top !important;
+}
+
+.experiment-details-table > table > tbody > tr  > td {
+  vertical-align: top !important;
+}
+.experiment-details-table > table > tbody > tr  > td {
+  vertical-align: top !important;
+}
+
+.experiment-details-tabs div button[data-state]:not([data-state='active']) {
+  border : 1px solid lightgray;
+  cursor: pointer;
+  margin:2px;
+}
+
+
+div.divide-y.divide-\[var\(--ui-border\)\].scroll-py-1 div[role='group'] {
+  max-height: 150px;
+  overflow-y:scroll;
+}

--- a/ui/app/components/Project/Experiment/List.vue
+++ b/ui/app/components/Project/Experiment/List.vue
@@ -403,7 +403,7 @@ const columns = ref<TableColumn<ProjectExperiment>[]>([
       return h(UButton, {
         color: "neutral",
         variant: "ghost",
-        label: "Directional Pricing",
+        label: "Directional Cost",
         icon: isSorted
           ? isSorted === "asc"
             ? "i-lucide-arrow-up-narrow-wide"
@@ -413,7 +413,7 @@ const columns = ref<TableColumn<ProjectExperiment>[]>([
         onClick: () => column.toggleSorting(column.getIsSorted() === "asc"),
       });
     },
-    label: 'Directional Pricing',
+    label: 'Directional Cost',
     accessorKey: "directional_pricing",
     enableHiding: true,
     sortingFn: (rowA, rowB) => {
@@ -576,7 +576,7 @@ const columnVisibility = ref({
       <template #directional_pricing-cell="{row}">     
         <div class="w-full">
             <UTooltip   :content="{side: 'right'}">
-                    <a class="text-blue-500 hover:underline" href="#">{{row.original?.config?.directional_pricing}}</a>
+                    <a class="text-blue-500 hover:underline" href="#">{{useHumanCurrencyAmount(row.original?.config?.directional_pricing)}}</a>
                     <template #content>
                       <UCard class="w-full">
                         <table class="w-full">

--- a/ui/app/components/Project/Experiment/ValidList.vue
+++ b/ui/app/components/Project/Experiment/ValidList.vue
@@ -290,10 +290,10 @@ const columns = ref<TableColumn<ValidExperiment>[]>([
     label: "Evaluation Inferencing Model"
   },
   {
-    header: 'Directional Pricing',
+    header: 'Directional Cost',
     enableHiding: true,
     accessorKey: "directional_pricing",
-    label: "Directional Pricing"
+    label: "Directional Cost"
   },
   {
     header: ({ column }) => {
@@ -394,7 +394,7 @@ const columnVisibility = ref({
       <template #directional_pricing-cell="{ row }">
         <div class="w-full">
               <UTooltip   :content="{side: 'right'}">
-                <a class="text-blue-500 hover:underline" href="#">{{row.original.directional_pricing}}</a>
+                <a class="text-blue-500 hover:underline" href="#">{{useHumanCurrencyAmount(row.original.directional_pricing)}}</a>
                 <template #content>
                   <UCard class="w-full">
                     <table class="w-full">

--- a/ui/app/pages/projects/[id]/experiments/[experimentId].vue
+++ b/ui/app/pages/projects/[id]/experiments/[experimentId].vue
@@ -35,6 +35,10 @@ useHead({
 
 const columns = ref<TableColumn<ExperimentQuestionMetric>[]>([
   {
+    header: "S.No",
+    accessorKey: "sno"
+   },
+  {
     header: "Question",
     accessorKey: "question",
   },
@@ -82,7 +86,7 @@ const items = ref([
     <UTabs
       :items="items"
       :unmount-on-hide="false"
-      class="w-full"
+      class="w-full experiment-details-tabs"
       variant="pill"
     >
       <template #account="{ item }">
@@ -98,12 +102,15 @@ const items = ref([
             </div>
           </template>
           <UTable
-            class="h-100"
+            class="h-100 experiment-details-table"            
             sticky
             :columns="columns"
             :data="questionMetrics?.question_metrics"
             :loading="isLoading"
           >
+           <template #sno-cell="{ row }">
+            <td>{{ row.index + 1 }}</td>
+          </template>
             <template #guardrail_input_assessment-cell="{ row }">
               <template v-if="row.original.guardrail_input_assessment">
                 <ProjectExperimentAssessments


### PR DESCRIPTION
1. dropdown items height adjusted, showing scrollbar on exceeding its maximum height
2. table columns dropdown height adjusted
3. experiment details page table cell data aligned to top
4. experiment details page, inactive tab buttons border added
5. renamed direction pricing to cost
6. showing $ symbol before directional cost in table
7. added serial no column to experiment details table