### PR TITLE
BugFix - https://github.com/FissionAI/FloTorch/issues/356 - Unique S3 Bucket name

### DIFF
--- a/cfn/dynamodb-template.yaml
+++ b/cfn/dynamodb-template.yaml
@@ -160,7 +160,7 @@ Resources:
   DataBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub "flotorch-data-${TableSuffix}"
+      BucketName: !Sub "flotorch-data-${TableSuffix}-${AWS::AccountId}-${AWS::Region}"
       VersioningConfiguration:
         Status: Enabled
       PublicAccessBlockConfiguration:


### PR DESCRIPTION
### Bugfix
[https://github.com/FissionAI/FloTorch/issues/356](https://github.com/FissionAI/FloTorch/issues/356)

- S3 Bucket name needs to be globally unique to prevent stackset failues. 
- Current naming _`flotorch-data-${tablePrefix}`_ is not scalable, Appending AccountId and region for uniqueness